### PR TITLE
Fetch Function Refactor (MyPosts, Categories)

### DIFF
--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -1,41 +1,25 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import "./CategoryList.css";
+import { fetchCategories, createCategory } from "../../managers/CatManager";
 
 export const CategoryList = () => {
-  const navigate = useNavigate();
   const [categories, setCategories] = useState([]);
   const initialCatState = {
     label: "",
   };
   const [category, updateCategory] = useState(initialCatState);
 
+  const fetchAndSetCategories = async () => {
+    const catArray = await fetchCategories();
+    setCategories(catArray);
+  };
+
   useEffect(() => {
     fetchAndSetCategories();
   }, []);
 
-  const fetchAndSetCategories = async () => {
-    let url = "http://localhost:8000/categories";
-
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Token ${localStorage.getItem("auth_token")}`,
-      },
-    });
-    const catArray = await response.json();
-
-    setCategories(catArray);
-  };
-
-  const createCategory = async (evt) => {
-    await fetch("http://localhost:8000/categories", {
-      method: "POST",
-      headers: {
-        Authorization: `Token ${localStorage.getItem("auth_token")}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(category),
-    });
+  const createAndRefreshCategories = async () => {
+    await createCategory(category);
     fetchAndSetCategories();
   };
 
@@ -74,7 +58,7 @@ export const CategoryList = () => {
               className="cat-input"
             />
           </fieldset>
-          <button onClick={createCategory} className="button">
+          <button onClick={createAndRefreshCategories} className="button">
             Create
           </button>
         </div>

--- a/src/components/posts/MyPosts.js
+++ b/src/components/posts/MyPosts.js
@@ -1,23 +1,18 @@
 import { useState, useEffect } from "react";
 import "./PostList.css";
 import { useNavigate } from "react-router-dom";
+import { fetchMyPosts } from "../../managers/PostManager";
 
 export const MyPostList = () => {
   const [myPosts, setMyPosts] = useState([]);
   const navigate = useNavigate();
 
-  const fetchMyPosts = async () => {
-    const response = await fetch("http://localhost:8000/posts?user=current", {
-      headers: {
-        Authorization: `Token ${localStorage.getItem("auth_token")}`,
-      },
-    });
-    const posts = await response.json();
-    setMyPosts(posts);
-  };
-
   useEffect(() => {
-    fetchMyPosts();
+    const fetchData = async () => {
+      const posts = await fetchMyPosts();
+      setMyPosts(posts);
+    };
+    fetchData();
   }, []);
 
   const btnToCreate = () => {

--- a/src/managers/CatManager.js
+++ b/src/managers/CatManager.js
@@ -1,0 +1,19 @@
+export const fetchCategories = async () => {
+  const response = await fetch("http://localhost:8000/categories", {
+    headers: {
+      Authorization: `Token ${localStorage.getItem("auth_token")}`,
+    },
+  });
+  return response.json();
+};
+
+export const createCategory = async (newCategory) => {
+  await fetch("http://localhost:8000/categories", {
+    method: "POST",
+    headers: {
+      Authorization: `Token ${localStorage.getItem("auth_token")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(newCategory),
+  });
+};

--- a/src/managers/PostManager.js
+++ b/src/managers/PostManager.js
@@ -1,9 +1,18 @@
 export const getPosts = () => {
-    return fetch("http://localhost:8000/posts", {
-      headers: {
-        Authorization: `Token ${
-          JSON.parse(localStorage.getItem("auth_token")).token
-        }`
-      },
-    }).then((res) => res.json());
-  };
+  return fetch("http://localhost:8000/posts", {
+    headers: {
+      Authorization: `Token ${
+        JSON.parse(localStorage.getItem("auth_token")).token
+      }`,
+    },
+  }).then((res) => res.json());
+};
+
+export const fetchMyPosts = async () => {
+  const response = await fetch("http://localhost:8000/posts?user=current", {
+    headers: {
+      Authorization: `Token ${localStorage.getItem("auth_token")}`,
+    },
+  });
+  return response.json();
+};


### PR DESCRIPTION
## Overview:

- Cleaned up MyPosts and CategoryList modules by moving API call functions to corresponding Manager modules, with some refactoring of the functions themselves

## Testing:

1. Git fetch and checkout this branch in your client code: ` lh-organizing `
2. Run the debugger in your API code
3. Npm start your client app
4. After logging in to the app...
    - navigate to My Posts and verify only current user Posts are rendered
    - navigate to Category Manager and create a Category, verify the list is re-rendered with new Category
5. Check the MyPosts and CategoryList modules themselves and verify the API functions are now being imported from the Manager modules