### PR TITLE
Sn category modals

### DIFF
--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -1,6 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./CategoryList.css";
-import { fetchCategories, createCategory } from "../../managers/CatManager";
+import {
+  fetchCategories,
+  createCategory,
+  deleteCategory,
+  editThisCategory,
+} from "../../managers/CatManager";
 
 export const CategoryList = () => {
   const [categories, setCategories] = useState([]);
@@ -8,6 +13,8 @@ export const CategoryList = () => {
     label: "",
   };
   const [category, updateCategory] = useState(initialCatState);
+  const [editCategory, setEditCategory] = useState({});
+  const manageCategory = useRef();
 
   const fetchAndSetCategories = async () => {
     const catArray = await fetchCategories();
@@ -23,13 +30,64 @@ export const CategoryList = () => {
     fetchAndSetCategories();
   };
 
+  const updateThisCategory = async (event) => {
+    event.preventDefault();
+    const catCopy = {
+      id: editCategory.id,
+      label: editCategory.label,
+    };
+    await editThisCategory(catCopy).then(() => {
+      fetchAndSetCategories();
+      handleCloseTags();
+      setEditCategory("")
+    });
+  }
+
+  const handleManageCat = () => {
+    if (manageCategory.current) {
+      manageCategory.current.showModal();
+    }
+  };
+
+  const handleCloseTags = () => {
+    if (manageCategory.current) {
+      manageCategory.current.close();
+    }
+  };
+
+  const handleDelete = (cat) => {
+    deleteCategory(cat).then(() => {
+      fetchAndSetCategories();
+    });
+  };
+
   const displayCategories = () => {
     if (categories && categories.length) {
-      return categories.map((cat) => (
+      return categories.map((cat) => {
+        return(
         <div key={cat.id}>
+          <button
+            type="button"
+            className="modal-box"
+            onClick={() => {
+              setEditCategory(cat);
+              handleManageCat();
+            }}
+          >
+            <i className="settings-icon fas fa-book"></i>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              handleDelete(cat);
+            }}
+          >
+            <i className="settings-icon fas fa-trash"></i>
+          </button>
           <div className="cat-item">{cat.label}</div>
         </div>
-      ));
+      )});
     }
 
     return <h3>Loading Categories...</h3>;
@@ -37,6 +95,30 @@ export const CategoryList = () => {
 
   return (
     <>
+          <dialog className="manage-tags" ref={manageCategory}>
+        <div className="tag-modal">
+          <fieldset>
+          <input
+          className="input-text"
+            onChange={(event) => {
+              const tagCopy = { ...editCategory };
+              tagCopy.label = event.target.value;
+              setEditCategory(tagCopy);
+            }}
+          />
+          </fieldset>
+        </div>
+        <div>
+          <button className="save-button" onClick={(event) => {
+                updateThisCategory(event)}}>
+            Save Tag
+          </button>
+          <button className="exit-button" onClick={handleCloseTags}>
+            Cancel
+          </button>
+        </div>
+      </dialog>
+
       <div className="comp-container">
         <div className="categories">
           <span className="header">Categories</span>

--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -38,7 +38,7 @@ export const CategoryList = () => {
     };
     await editThisCategory(catCopy).then(() => {
       fetchAndSetCategories();
-      handleCloseTags();
+      handleCloseCategory();
       setEditCategory("")
     });
   }
@@ -49,7 +49,7 @@ export const CategoryList = () => {
     }
   };
 
-  const handleCloseTags = () => {
+  const handleCloseCategory = () => {
     if (manageCategory.current) {
       manageCategory.current.close();
     }
@@ -113,7 +113,7 @@ export const CategoryList = () => {
                 updateThisCategory(event)}}>
             Save Tag
           </button>
-          <button className="exit-button" onClick={handleCloseTags}>
+          <button className="exit-button" onClick={handleCloseCategory}>
             Cancel
           </button>
         </div>

--- a/src/components/tags/AllTags.js
+++ b/src/components/tags/AllTags.js
@@ -72,11 +72,6 @@ export const AllTags = () => {
     }
   };
 
-  const handleTagChange = (event) => {
-    const tagCopy = { ...tags };
-    tagCopy[event.target.name] = event.target.value;
-    setUpdatedTag(tagCopy);
-  };
 
   return (
     <>

--- a/src/managers/CatManager.js
+++ b/src/managers/CatManager.js
@@ -17,3 +17,23 @@ export const createCategory = async (newCategory) => {
     body: JSON.stringify(newCategory),
   });
 };
+
+export const editThisCategory = async (category) => {
+  await fetch(`http://localhost:8000/categories/${category.id}`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Token ${localStorage.getItem("auth_token")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(category)})
+};
+
+export const deleteCategory = (category) => {
+  return fetch(`http://localhost:8000/categories/${category.id}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Token ${localStorage.getItem("auth_token")}`,
+      "Content-Type": "application/json",
+    },
+  });
+};


### PR DESCRIPTION
## Setup Modals for categories
* added new functionality DeleteCategory, EditCategory into CatManager
* added UpdateThisCategory, HandleManageCat, HandleCloseCategory, and handleDelete to CategoryList.js
## How To Test
* pull down sn-category-modals
* make sure npm start is running
* make sure api is running
* navigate to /categories
* edit button(book) and Delete(trash) buttons are clickable
* when edit is clicked the modal window should pop up and will let you change the name of the selected category. 
* click save and page will rerender
* when delete is clicked said category is destroyed and page rerenders